### PR TITLE
Use package refine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,11 @@ install: init.el .local/autoloads.el
 autoload: init.el
 >@$(EMACS) -f moon/generate-autoload-file
 
+autoremove: init.el .local/autoloads.el
+>@$(EMACS) -f moon/remove-unused-package
+
+update: init.el .local/autoloads.el
+>@$(EMACS) -f moon/update-package
+
 clean:
 >rm -f .*/**/*.elc;rm -f */**/*.elc

--- a/core/core-package.el
+++ b/core/core-package.el
@@ -130,8 +130,8 @@ Can take multiple packages.
 e.g. (package| evil evil-surround)"
   (dolist (package package-list)
     (add-to-list 'moon-package-list (symbol-name package))
-    (fset (intern (format "post-config-%s" (symbol-name package))) '(lambda () ()))
-    (fset (intern (format "pre-init-%s" (symbol-name package))) '(lambda () ()))
+    ;; (fset (intern (format "post-config-%s" (symbol-name package))) '(lambda () ()))
+    ;; (fset (intern (format "pre-init-%s" (symbol-name package))) '(lambda () ()))
     ))
 
 (defmacro moon| (&rest star-list)
@@ -151,18 +151,24 @@ If called multiple times, the stars declared first will be in the front of moon-
 (defmacro post-config| (package &rest to-do-list)
   "Expressions to be called after (use-package PACKAGE :config)"
   (let (
-        (hook-symbol (intern (format "post-config-%s" package)))
+        (func-symbol (intern (format "post-config-%s" package)))
         )
-    (fset hook-symbol (append (symbol-function hook-symbol) to-do-list))
+    (unless (fboundp func-symbol)
+      (fset func-symbol '(lambda () ()))
+      )
+    (fset func-symbol (append (symbol-function func-symbol) to-do-list))
     )
   )
 
 (defmacro pre-init| (package &rest to-do-list)
   "Expressions to be called after (use-package PACKAGE :init)"
   (let (
-        (hook-symbol (intern (format "pre-init-%s" package)))
+        (func-symbol (intern (format "pre-init-%s" package)))
         )
-    (fset hook-symbol (append (symbol-function hook-symbol) to-do-list))
+    (unless (fboundp func-symbol)
+      (fset func-symbol '(lambda () ()))
+      )
+    (fset func-symbol (append (symbol-function func-symbol) to-do-list))
     )
   )
 

--- a/core/core-package.el
+++ b/core/core-package.el
@@ -184,9 +184,21 @@ to `moon-grand-use-pacage-call' to be evaluated at the end of `moon-initialize-s
          ,package
          ,@rest-list
          :init
-         (eval (list (intern (format "pre-init-%s" (symbol-name ',package)))))
+         (let (
+               (symb (intern (format "pre-init-%s" (symbol-name ',package))))
+               )
+           (when (fboundp symb)
+             (eval (list symb)))
+           )
+         ;; (eval (list (intern (format "pre-init-%s" (symbol-name ',package)))))
          :config
-         (eval (list (intern (format "post-config-%s" (symbol-name ',package)))))
+         (let (
+               (symb (intern (format "post-config-%s" (symbol-name ',package))))
+               )
+           (when (fboundp symb)
+             (eval (list symb)))
+           )
+         ;; (eval (list (intern (format "post-config-%s" (symbol-name ',package)))))
          ))
      )
     )

--- a/core/core-package.el
+++ b/core/core-package.el
@@ -157,7 +157,7 @@ If called multiple times, the stars declared first will be in the front of moon-
     )
   )
 
-(defmacro pre-init (package &rest to-do-list)
+(defmacro pre-init| (package &rest to-do-list)
   "Expressions to be called after (use-package PACKAGE :init)"
   (let (
         (hook-symbol (intern (format "pre-init-%s" package)))
@@ -192,6 +192,7 @@ to `moon-grand-use-pacage-call' to be evaluated at the end of `moon-initialize-s
     )
   )
 
+
 ;; (defun post-config-evil () (message "it works!"))
 ;; (defun pre-init-evil () (message "it works!"))
 
@@ -223,8 +224,31 @@ to `moon-grand-use-pacage-call' to be evaluated at the end of `moon-initialize-s
   (moon-initialize-star)
   (package-refresh-contents)
   (dolist (package moon-package-list)
-    (package-install (intern package))
+    (unless
+        (package-installed-p (intern package))
+        (package-install (intern package))
+        )
     ))
+
+(defun moon/update-package ()
+  (interactive)
+  (moon-initialize)
+  (moon-initialize-star)
+  ;; https://oremacs.com/2015/03/20/managing-emacs-packages/
+  (save-window-excursion
+    (package-list-packages t)
+    (package-menu-mark-upgrades)
+    (package-menu-execute t)))
+
+(defun moon/remove-unused-package ()
+  (interactive)
+  (moon-initialize)
+  (moon-initialize-star)
+  (dolist (package package-activated-list)
+    (when (member (symbol-name package) moon-package-list)
+      (package-delete '(:name package)))
+    )
+  )
 
 (defun moon/generate-autoload-file ()
   (interactive)

--- a/star/autocomplete/company/config.el
+++ b/star/autocomplete/company/config.el
@@ -1,4 +1,4 @@
-(use-package company
+(use-package| company
   :diminish ('company-mode . "Ⓒ")
   :hook (prog-mode . company-mode)
   :defer t

--- a/star/autocomplete/ivy/config.el
+++ b/star/autocomplete/ivy/config.el
@@ -1,4 +1,4 @@
-(use-package ivy
+(use-package| ivy
   :diminish ('ivy-mode . "ⓘ")
   :config
   (ivy-mode 1)
@@ -36,8 +36,8 @@
     )
   )
 
-(use-package swiper :commands (ivy-mode))
-(use-package counsel :commands (ivy-mode))
-(use-package smex
+(use-package| swiper :commands (ivy-mode))
+(use-package| counsel :commands (ivy-mode))
+(use-package| smex
 	      :commands (ivy-mode)
 	      :config (setq smex-save-file (concat moon-local-dir "smex-items")))

--- a/star/basic/basic-ui/config.el
+++ b/star/basic/basic-ui/config.el
@@ -64,7 +64,7 @@
 ;; Package
 ;;
 
-(use-package spacemacs-theme
+(use-package| spacemacs-theme
   :defer t
   :init (load-theme 'spacemacs-dark t))
 

--- a/star/basic/edit/config.el
+++ b/star/basic/edit/config.el
@@ -1,4 +1,4 @@
-(use-package
+(use-package|
   expand-region
   :commands er/expand-region
   :general (default-leader
@@ -6,14 +6,14 @@
              )
   )
 
-(use-package
+(use-package|
   undo-tree
   :diminish undo-tree-mode
   :config (global-undo-tree-mode)
   (setq undo-tree-visualizer-timestamps t
         undo-tree-visualizer-diff t))
 
-(use-package
+(use-package|
   recentf-ext
   :commands (recentf counsel-recentf)
   )

--- a/star/basic/evil/config.el
+++ b/star/basic/evil/config.el
@@ -1,4 +1,4 @@
-(use-package evil
+(use-package| evil
   :config
   (evil-mode 1)
   ;; fix paste issue in evil visual mode
@@ -7,6 +7,9 @@
   (default-leader "ij" #'evil-insert-line-below
     "ik" #'evil-insert-line-above)
   )
+
+(post-config| evil
+              (message "it works!"))
 
 (use-package evil-matchit
   :hook (prog-mode . evil-matchit-mode)

--- a/star/basic/evil/config.el
+++ b/star/basic/evil/config.el
@@ -11,14 +11,14 @@
 (post-config| evil
               (message "it works!"))
 
-(use-package evil-matchit
+(use-package| evil-matchit
   :hook (prog-mode . evil-matchit-mode)
   )
 
-(use-package evil-search-highlight-persist
+(use-package| evil-search-highlight-persist
   :commands (evil-search swiper))
 
-(use-package evil-surround
+(use-package| evil-surround
   :hook evil-visual-state
   :config
   (general-define-key :states 'visual
@@ -28,7 +28,7 @@
   )
 
 
-(use-package evil-nerd-commenter
+(use-package| evil-nerd-commenter
   :commands evilnc-comment-operator
   :general
   (:keymaps 'visual
@@ -36,10 +36,10 @@
             "c" #'evilnc-comment-operator)
   )
 
-(use-package evil-mc
+(use-package| evil-mc
   :commands (evil-mc-find-next-cursor
              evil-mc-find-prev-cursor))
 
-(use-package evil-escape
+(use-package| evil-escape
   :diminish evil-escap-mode
   :config (evil-escape-mode 1))

--- a/star/basic/key/config.el
+++ b/star/basic/key/config.el
@@ -60,7 +60,7 @@
 		      "TAB" #'indent-region)
   )
 
-(use-package which-key
+(use-package| which-key
   :diminish 'which-key-mode
   :config (which-key-mode 1))
 

--- a/star/basic/ui/config.el
+++ b/star/basic/ui/config.el
@@ -19,13 +19,13 @@
 ;; Package
 ;;
 
-(use-package rainbow-delimiters
+(use-package| rainbow-delimiters
   :defer t
   :hook (prog-mode . rainbow-delimiters-mode)
   )
 
 
-;; (use-package powerline
+;; (use-package| powerline
 ;;   :config
 ;;   (require 'powerline)
 ;;   (setq powerline-default-separator 'slant)
@@ -34,7 +34,7 @@
 ;;   (powerline-default-theme)
 ;;   )
 
-(use-package spaceline
+(use-package| spaceline
   :defer t
   :init (add-hook
          'moon-post-init-hook
@@ -55,14 +55,14 @@
 
 
 
-(use-package nlinum
+(use-package| nlinum
   :hook (prog-mode . nlinum-mode)
   :config
   (moon/match-number-line-backgroud-color)
   (add-hook 'moon-post-load-theme-hook #'moon/match-number-line-backgroud-color)
   )
 
-;; (use-package hlinum
+;; (use-package| hlinum
 ;;   :hook linum-mode
 ;;   :config
 ;;   (hlinum-activate)
@@ -70,5 +70,5 @@
 ;;   (add-hook 'spacemacs-post-theme-change-hook #'sync-hlinum-face)
 ;;   )
 
-(use-package diminish
+(use-package| diminish
   :config (diminish 'eldoc-mode))

--- a/star/basic/ui/config.el
+++ b/star/basic/ui/config.el
@@ -1,4 +1,11 @@
 ;;
+;; Var
+;;
+
+;; https://www.reddit.com/r/emacs/comments/4v7tcj/does_emacs_have_a_hook_for_when_the_theme_changes/
+
+
+;;
 ;; Config
 ;;
 
@@ -50,7 +57,9 @@
 
 (use-package nlinum
   :hook (prog-mode . nlinum-mode)
-  :defer t
+  :config
+  (moon/match-number-line-backgroud-color)
+  (add-hook 'moon-post-load-theme-hook #'moon/match-number-line-backgroud-color)
   )
 
 ;; (use-package hlinum

--- a/star/casouri/casouri/config.el
+++ b/star/casouri/casouri/config.el
@@ -1,4 +1,4 @@
-(use-package nyan-mode
+(use-package| nyan-mode
   :init(setq nyan-wavy-trail t)
   :config
   (nyan-mode 1)


### PR DESCRIPTION
Ok I just copied those from commit message.

Before the change package| macro add ```post-config-xxx``` and ```pre-init-xxx```
for every package declared by it. Then ```use-package|``` macro will add those
package to ```use-packag```e macro under ```:init``` and ```:config``` flag.
However, almost 99% of the packages doesn't have any ```post-config```
or ```pre-init``` configured, resulting in ```use-package``` calling hundreds of
empty functions when loading packaged. 

When you have many packages,
there is a good amount of performance draw back. 

Now ```package|``` macro
doesn't add ```post-config``` nor ```pre-init```, it is done by ```post-config|``` and
```pre-init|``` macro when they detect that no function is created. In other word
```post-config``` and ```pre-init``` are created only when you actually configure
them by ```post-config|``` or ```pre-init|``` macro. Then in ```use-package|``` macro it
only run them when they exist. A if test should be cheaper than a empty
functon call.