### PR TITLE
 Also detect minibuffer-mode

### DIFF
--- a/star/edit.el
+++ b/star/edit.el
@@ -96,6 +96,7 @@
 (load-package yasnippet
   :config
   (yas-global-mode)
+  (yas--define-parents 'minibuffer-mode '(emacs-lisp-mode))
   (yas--define-parents 'minibuffer-inactive-mode '(emacs-lisp-mode))
   (with-eval-after-load 'hippie-exp
     (add-to-list 'hippie-expand-try-functions-list #'yas-expand)))


### PR DESCRIPTION
Recently, on Emacs master branch, a commit 55db25b257 was pushed to fix
Emacs bug [47150](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=47150). This bug was related to an incorrect implementation of
minibuffer-inactive-mode. It used to be the case that after the first
usage of the minibuffer, it stucks in minibuffer-inactive-mode, though
minibuffer-inactive-mode was intended for a completely different
purpose, and the minibuffer on the current frame should NOT be inactive.
The new design is to have two possible major modes for the minibuffer:
minibuffer-mode when it is active, and minibuffer-inactive-mode when it
is inactive.