### PR TITLE
Fixes to info-pretty

### DIFF
--- a/site-lisp/info-pretty.el
+++ b/site-lisp/info-pretty.el
@@ -1,4 +1,4 @@
-;;; pretty-info.el --- Prettier Info      -*- lexical-binding: t; -*-
+;;; info-pretty.el --- Prettier Info      -*- lexical-binding: t; -*-
 
 ;; Author: Yuan Fu <casouri@gmail.com>
 
@@ -311,6 +311,6 @@ Moves point."
   (when (derived-mode-p 'Info-mode)
     (revert-buffer nil t)))
 
-(provide 'pretty-info)
+(provide 'info-pretty)
 
-;;; pretty-info.el ends here
+;;; info-pretty.el ends here

--- a/site-lisp/info-pretty.el
+++ b/site-lisp/info-pretty.el
@@ -54,6 +54,9 @@
 (defface info-pretty-variable `((t . (:inherit italic)))
   "Face for variables in a function definition.")
 
+(defvar-local info-pretty--face-remap-cookie nil
+  "Cookie returned by face-remap-add-relative.")
+
 (defun info-pretty--next-block ()
   "Return (BEG . END) of next text block after point.
 Move point to BEG.
@@ -299,7 +302,9 @@ Moves point."
             (goto-char end-mark))))
       (Info-fontify-node)
       (visual-line-mode)
-      (face-remap-add-relative 'link '(:inherit info-pretty-body)))))
+      (unless info-pretty--face-remap-cookie
+        (setq info-pretty--face-remap-cookie
+              (face-remap-add-relative 'link 'info-pretty-body))))))
 
 (define-minor-mode info-pretty-mode
   "Prettified Info."


### PR DESCRIPTION
I just came across your info-pretty implementation and I'm finding it very
useful! I needed to make some small changes to get it to work properly.  This
PR has two commits:

* Finish renaming pretty-info to info-pretty

Change the file header, footer, and `provide` declaration to refer to
`info-pretty` instead of its old name, `pretty-info`.

* info-pretty: Avoid repeated face remaps

Calling `face-remap-add-relative` unconditionally from `Info-selection-hook`
adds an entry to `face-remapping-alist` every time a section is opened.  This
is especially problematic if, for example, the 'info-pretty-body' face uses
relative font heights, which end up being multiplied together.

Instead, save the cookie returned by `face-remap-add-relative` as a
buffer-local variable and check for it before adding the face remap again.

Also, adding a face remapping of the form `(:inherit face)` is exactly
equivalent to just remapping to 'face', so do that instead.